### PR TITLE
Add more descriptive errors

### DIFF
--- a/cryptex/cryptex.py
+++ b/cryptex/cryptex.py
@@ -5,6 +5,8 @@ import time
 from Cryptodome.Cipher import AES
 from Cryptodome.Random import get_random_bytes
 
+from .errors import KeysizeError, ExpirationError
+
 
 _AES_256_KEYSIZE_BYTES = 32
 _TAG_DIGEST_LENGTH_BYTES = 16
@@ -15,8 +17,9 @@ class Cryptex(object):
     def __init__(self, key):
         self.key = base64.urlsafe_b64decode(key)
         if len(self.key) != _AES_256_KEYSIZE_BYTES:
-            raise ValueError(
-                'Keysize is invalid. Key must be 32 bytes.')
+            raise KeysizeError(
+                'Keysize is invalid. Key must be 32 bytes.'
+            )
 
     def encrypt(self, data, ttl=None):
         nonce = get_random_bytes(_NONCE_LENGTH_BYTES)
@@ -65,8 +68,10 @@ class Cryptex(object):
         timestamp = struct.unpack('<L', timestamp)[0]
         if timestamp != 0:
             if current_time > timestamp:
-                raise ValueError(
-                    'Token is past expiration time.')
+                raise ExpirationError(
+                    'Token is past expiration time.',
+                    current_time - timestamp,
+                )
         return plaintext
 
     def generate_key():

--- a/cryptex/errors.py
+++ b/cryptex/errors.py
@@ -1,0 +1,22 @@
+class KeysizeError(Exception):
+    """Raised when keysize is invalid for the Cryptex operation.
+
+    Attributes:
+        message -- explanation of error
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+
+class ExpirationError(Exception):
+    """Raised when the token is past the expiration ttl length.
+
+    Attributes:
+        message -- explanation of error
+        expired -- number of seconds since message expired
+    """
+
+    def __init__(self, message, expired):
+        self.message = message
+        self.expired = expired

--- a/cryptex/errors.py
+++ b/cryptex/errors.py
@@ -20,3 +20,15 @@ class ExpirationError(Exception):
     def __init__(self, message, expired):
         self.message = message
         self.expired = expired
+
+
+class NoValidKeyError(Exception):
+    """Raised when no valid key could be used during multicryptex decryption.
+
+    Attributes:
+        message -- explanation of error
+    """
+
+
+    def __init__(self, message):
+        self.message = message

--- a/cryptex/errors.py
+++ b/cryptex/errors.py
@@ -1,4 +1,10 @@
-class KeysizeError(Exception):
+class CryptexError(Exception):
+    """Generic base class for all Cryptex errors.
+    """
+    pass
+
+
+class KeysizeError(CryptexError):
     """Raised when keysize is invalid for the Cryptex operation.
 
     Attributes:
@@ -9,7 +15,7 @@ class KeysizeError(Exception):
         self.message = message
 
 
-class ExpirationError(Exception):
+class ExpirationError(CryptexError):
     """Raised when the token is past the expiration ttl length.
 
     Attributes:
@@ -22,13 +28,12 @@ class ExpirationError(Exception):
         self.expired = expired
 
 
-class NoValidKeyError(Exception):
+class NoValidKeyError(CryptexError):
     """Raised when no valid key could be used during multicryptex decryption.
 
     Attributes:
         message -- explanation of error
     """
-
 
     def __init__(self, message):
         self.message = message

--- a/cryptex/multicryptex.py
+++ b/cryptex/multicryptex.py
@@ -1,4 +1,5 @@
 from .cryptex import Cryptex
+from .errors import NoValidKeyError
 
 
 class MultiCryptex(object):
@@ -15,4 +16,6 @@ class MultiCryptex(object):
             except ValueError:
                 continue
         else:
-            raise ValueError("No valid key found or token expired.")
+            raise NoValidKeyError(
+                "No valid key in keylist."
+            )

--- a/tests/test_cryptex.py
+++ b/tests/test_cryptex.py
@@ -4,6 +4,7 @@ import time
 
 from Cryptodome.Random import get_random_bytes
 from cryptex import Cryptex, MultiCryptex
+from cryptex.errors import KeysizeError, ExpirationError, NoValidKeyError
 
 
 class TestCryptex(unittest.TestCase):
@@ -19,7 +20,7 @@ class TestCryptex(unittest.TestCase):
     def test_keysize_error(self):
         # Create a key with an invalid keysize for AES-256
         invalid_key = base64.urlsafe_b64encode(get_random_bytes(16))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeysizeError):
             Cryptex(invalid_key)
 
     def test_encryption_and_decryption(self):
@@ -53,7 +54,7 @@ class TestCryptex(unittest.TestCase):
 
         # Test ttl by sleeping over expiration time
         time.sleep(6)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ExpirationError):
             cryptex.decrypt(token)
 
     def test_multicryptex_encryption_and_decryption(self):
@@ -109,7 +110,7 @@ class TestCryptex(unittest.TestCase):
 
         # Test ttl by sleeping over expiration time
         time.sleep(6)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ExpirationError):
             multicryptex.decrypt(token)
 
     def test_multicryptex_no_key_error(self):
@@ -122,5 +123,5 @@ class TestCryptex(unittest.TestCase):
             self.fail("Encryption failed with {}".format(e))
         self.assertNotEqual(self.test_data, token)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NoValidKeyError):
             multicryptex.decrypt(token)


### PR DESCRIPTION
This PR is for issue #2.

**What?**
1) Adds a file `errors.py`.
2) Adds four user-defined errors to `cryptex.errors`
    - `CryptexError` -- Generic base class for all Cryptex errors.
    - `KeysizeError` -- Raised when the key is an invalid size for AES-256.
    - `ExpirationError`-- Raised when the token's is past the ttl expiration length.
    - `NoValidKeyError` -- Raised when the token could not be decrypted via `MultiCryptex` after it has exhausted its key list.
3) Implements the errors in `cryptex.cryptex`, `cryptex.multicryptex`, as well as the tests at `tests.test_cryptex`.

**Why?**
1) The errors used in the previous version were not descriptive and used the same error which made it difficult for a developer to check for a specific error.

**Tests run:**
1) `tests.test_cryptex`